### PR TITLE
카테고리/게시글/좋아요 API 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
           <Route path="/board/:id" element={<BoardDetail />} />
           <Route path="/board/:id/edit" element={<BoardEdit />} />
           <Route path="/docker-docs" element={<DockerDocsOverview />} />
-          <Route path="/docs/:chapterId/:stepId?" element={<DockerDocsDetail />} />
+          <Route path="/docs/:projectId/:chapterId" element={<DockerDocsDetail />} />
           <Route path="/thread" element={<ThreadList />} />
           <Route path="/thread/:threadId" element={<ThreadDetail />} />
           <Route path="/thread/:threadId/edit" element={<ThreadEdit />} />

--- a/src/components/common/NestedSidebar.tsx
+++ b/src/components/common/NestedSidebar.tsx
@@ -1,20 +1,22 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 
-// 대분류 -> 중분류 -> 소분류 설계
 interface Step {
   id: string;
   title: string;
 }
+
 interface Chapter {
   id: string;
   title: string;
   steps?: Step[];
 }
+
 interface Project {
   id: string;
   title: string;
   chapters: Chapter[];
 }
+
 interface Props {
   data: Project[];
 }
@@ -24,7 +26,7 @@ const NestedSidebar = ({ data }: Props) => {
   const location = useLocation();
 
   return (
-    <aside className="w-60 p-4 border-r border-gray-300 bg-white">
+    <aside className="w-60 p-4 border-r border-gray-300 bg-white overflow-y-auto h-screen">
       <h2 className="text-xl font-bold mb-4">📚 전체 프로젝트</h2>
       <ul className="space-y-2 text-sm">
         {data.map((project) => (
@@ -34,20 +36,21 @@ const NestedSidebar = ({ data }: Props) => {
               {project.chapters.map((chapter) => (
                 <li key={chapter.id}>
                   <div className="text-gray-700 font-semibold">{chapter.title}</div>
-                  <ul className="ml-4">
-                    {chapter.steps?.map((step) => (
-                      <li
-                        key={step.id}
-                        className={`cursor-pointer hover:underline ${
-                          location.pathname.includes(step.id)
-                            ? 'text-blue-600 font-semibold'
-                            : ''
-                        }`}
-                        onClick={() => navigate(`/threads/${step.id}`)}
-                      >
-                        {step.title}
-                      </li>
-                    ))}
+                  <ul className="ml-4 space-y-0.5 mt-1">
+                    {chapter.steps?.map((step) => {
+                      const isActive = location.pathname.includes(step.id);
+                      return (
+                        <li
+                          key={step.id}
+                          className={`cursor-pointer hover:underline ${
+                            isActive ? 'text-blue-600 font-semibold' : 'text-gray-700'
+                          }`}
+                          onClick={() => navigate(`/docs/${project.id}/${chapter.id}#${step.id}`)}
+                        >
+                          {step.title}
+                        </li>
+                      );
+                    })}
                   </ul>
                 </li>
               ))}

--- a/src/components/dockerDocs/SelectedStepThread.tsx
+++ b/src/components/dockerDocs/SelectedStepThread.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { X } from "lucide-react";
+import { X } from 'lucide-react';
 import ThreadCard from './ThreadCard';
+import api from '@/lib/api';
 
 const dummyThreads = [
   {
@@ -26,29 +28,86 @@ interface Props {
   onClose: () => void;
 }
 
+interface Thread {
+  id?: number;
+  threadId?: string; // 더미용
+  title: string;
+  summary: string;
+  likes: number;
+  dislikes: number;
+  comments: string[];
+}
+
 const SelectedStepThread = ({ stepId, onClose }: Props) => {
-    return (
-      <motion.div
-        initial={{ x: 400 }}
-        animate={{ x: 0 }}
-        exit={{ x: 400 }}
-        transition={{ duration: 0.3 }}
-        className="fixed top-0 right-0 h-full w-[400px] bg-white border-l shadow-lg z-50 p-6 overflow-y-auto"
-      >
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-bold">🧵 {stepId} 토론</h2>
-          <button onClick={onClose} className="text-gray-500 hover:text-black text-xl">
-            <X />
-          </button>
-        </div>
-  
-        <div className="mb-4 text-sm text-gray-600">이 스텝에 대한 게시글입니다.</div>
-  
-        {dummyThreads.map((t) => (
-          <ThreadCard key={t.threadId} {...t} />
-        ))}
-      </motion.div>
-    );
-  };
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchThreads = async () => {
+      try {
+        setLoading(true);
+        const res = await api.get('/post', { params: { categoryId: stepId } });
+
+        const data = res.data;
+
+        if (!Array.isArray(data) || data.length === 0) {
+          setThreads(dummyThreads);
+          return;
+        }
+
+        const normalized = data.map((post) => ({
+          id: post.id,
+          title: post.title,
+          summary: post.content.slice(0, 60),
+          likes: post.likes ?? 0,
+          dislikes: post.dislikes ?? 0,
+          comments: [],
+        }));
+
+        setThreads(normalized);
+      } catch (err) {
+        setThreads(dummyThreads);
+        setError('API 요청 실패 - 더미 데이터 사용');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchThreads();
+  }, [stepId]);
+
+  return (
+    <motion.div
+      initial={{ x: 400 }}
+      animate={{ x: 0 }}
+      exit={{ x: 400 }}
+      transition={{ duration: 0.3 }}
+      className="fixed top-0 right-0 h-full w-[400px] bg-white border-l shadow-lg z-50 p-6 overflow-y-auto"
+    >
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-bold">🧵 {stepId} 토론</h2>
+        <button onClick={onClose} className="text-gray-500 hover:text-black text-xl">
+          <X />
+        </button>
+      </div>
+
+      {loading && <div className="text-sm text-gray-400">로딩 중...</div>}
+      {error && <div className="text-sm text-red-500 mb-2">{error}</div>}
+
+      {threads.map((t) => (
+        <ThreadCard
+          key={t.id ?? t.threadId}
+          threadId={t.threadId ?? `post-${t.id}`}
+          title={t.title}
+          summary={t.summary}
+          likes={t.likes}
+          dislikes={t.dislikes}
+          comments={t.comments}
+        />
+      ))}
+    </motion.div>
+  );
+};
 
 export default SelectedStepThread;

--- a/src/components/dockerDocs/ThreadCard.tsx
+++ b/src/components/dockerDocs/ThreadCard.tsx
@@ -1,33 +1,123 @@
-import { useState } from "react";
-import { MessageSquare, ThumbsUp, ThumbsDown, ChevronDown, ChevronUp } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  MessageSquare,
+  ThumbsUp,
+  ThumbsDown,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import CommentList from "./CommentList";
 import { Link } from "react-router-dom";
+import api from "@/lib/api";
 
 type ThreadCardProps = {
-    threadId: string;
-    title: string;
-    summary: string;
-    likes: number;
-    dislikes: number;
-    comments: string[];
+  threadId: string; // 현재 화면 구조로는 게시글..
+  title: string;
+  summary: string;
+  likes: number;
+  dislikes: number;
+  comments: string[];
+  userId: number; // 이메일로 해야하나
 };
 
-const ThreadCard = ({ threadId, title, summary, likes, dislikes, comments } : ThreadCardProps) => {
+const ThreadCard = ({
+  threadId,
+  title,
+  summary,
+  likes,
+  dislikes,
+  comments,
+  userId,
+}: ThreadCardProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [userReaction, setUserReaction] = useState<"like" | "dislike" | null>(null);
+  const [reactionId, setReactionId] = useState<number | null>(null);
+  const [likeCount, setLikeCount] = useState(likes);
+  const [dislikeCount, setDislikeCount] = useState(dislikes);
+
+  useEffect(() => {
+    const fetchUserReaction = async () => {
+      try {
+        const res = await api.get("/like", {
+          params: { userId, postId: threadId },
+        });
+        if (Array.isArray(res.data) && res.data.length > 0) {
+          const reaction = res.data[0];
+          setUserReaction(reaction.reactionType);
+          setReactionId(reaction.id);
+        }
+      } catch (err) {
+        console.error("실패:", err);
+      }
+    };
+    fetchUserReaction();
+  }, [userId, threadId]);
+
+  // 좋아요 / 싫어요 클릭 이벤트
+  const handleReactionClick = async (type: "like" | "dislike") => {
+    try {
+      if (userReaction === null) {
+        const res = await api.post("/like", {
+          userId,
+          postId: threadId,
+          reactionType: type,
+        });
+        // res.data.id 안불러와짐 생성된 id 반환 필요 이거 있어야 다음 액션에 오류 없음
+        setReactionId(res.data.id);
+        setUserReaction(type);
+        type === "like"
+          ? setLikeCount((v) => v + 1)
+          : setDislikeCount((v) => v + 1);
+      } else if (userReaction === type) {
+        await api.delete(`/like/${reactionId}`);
+        setUserReaction(null);
+        setReactionId(null);
+        type === "like"
+          ? setLikeCount((v) => v - 1)
+          : setDislikeCount((v) => v - 1);
+      } else {
+        await api.patch(`/like/${reactionId}`, { reactionType: type });
+        if (type === "like") {
+          setLikeCount((v) => v + 1);
+          setDislikeCount((v) => v - 1);
+        } else {
+          setDislikeCount((v) => v + 1);
+          setLikeCount((v) => v - 1);
+        }
+        setUserReaction(type);
+      }
+    } catch (err) {
+      console.error("반응 처리 중 오류:", err);
+    }
+  };
 
   return (
     <div className="border rounded-lg p-4 mb-4 shadow-sm">
       <div className="flex justify-between items-start mb-2">
         <Link
-            to={`/thread/${threadId}`}
-            className="text-blue-700 font-semibold hover:underline block mb-1"
+          to={`/thread/${threadId}`}
+          className="text-blue-700 font-semibold hover:underline block mb-1"
         >
-            {title}
+          {title}
         </Link>
         <div className="text-sm text-gray-500 flex items-center gap-2">
-          <div className="flex items-center gap-1"><ThumbsUp size={14} /> {likes}</div>
-          <div className="flex items-center gap-1"><ThumbsDown size={14} /> {dislikes}</div>
+          <button
+            onClick={() => handleReactionClick("like")}
+            className={`flex items-center gap-1 ${
+              userReaction === "like" ? "text-blue-600 font-bold" : ""
+            }`}
+          >
+            <ThumbsUp size={14} /> {likeCount}
+          </button>
+          <button
+            onClick={() => handleReactionClick("dislike")}
+            className={`flex items-center gap-1 ${
+              userReaction === "dislike" ? "text-red-600 font-bold" : ""
+            }`}
+          >
+            <ThumbsDown size={14} /> {dislikeCount}
+          </button>
         </div>
       </div>
 
@@ -37,7 +127,7 @@ const ThreadCard = ({ threadId, title, summary, likes, dislikes, comments } : Th
         className="text-blue-600 text-sm mt-2 flex items-center gap-1"
         onClick={() => setIsExpanded((prev) => !prev)}
       >
-        {isExpanded ? "간략히 닫기" : "간략히 보기"}
+        {isExpanded ? "간략히 보기" : "자세히 보기"}
         {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
       </button>
 
@@ -52,7 +142,7 @@ const ThreadCard = ({ threadId, title, summary, likes, dislikes, comments } : Th
             className="overflow-hidden mt-2"
           >
             <div className="text-sm text-gray-800 mb-3">
-              📄 전체 본문 내용 표시 예시입니다. 이곳에 실제 본문이 들어갈 수 있어요. 쿠쿠루삥뽕
+              📄 전체 본문 내용 표시 예시입니다. 이곳에 실제 본문이 들어갈 수 있어요.
             </div>
             <CommentList comments={comments} />
           </motion.div>

--- a/src/data/docsData.ts
+++ b/src/data/docsData.ts
@@ -7,8 +7,8 @@ export const docsData = [
         id: '1',
         title: '1장. 도커의 이해',
         steps: [
-          { id: '1.1', title: '세팅 시작하기' },
-          { id: '1.2', title: '컨테이너의 이해' },
+          { id: '1.1', title: '1.1 세팅 시작하기' },
+          { id: '1.2', title: '1.2 컨테이너의 이해' },
         ],
       },
     ],
@@ -21,8 +21,8 @@ export const docsData = [
         id: '1',
         title: '1장. 자바스크립트 기본',
         steps: [
-          { id: '1.1', title: '변수와 상수' },
-          { id: '1.2', title: '함수와 조건문' },
+          { id: '1.1', title: '1.1 변수와 상수' },
+          { id: '1.2', title: '1.2 함수와 조건문' },
         ],
       },
     ],

--- a/src/hooks/useDocsData.ts
+++ b/src/hooks/useDocsData.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import api from '@/lib/api';
+import { docsData as fallbackDocsData } from '@/data/docsData';
+
+interface Step {
+  id: string;
+  title: string;
+}
+
+interface Chapter {
+  id: string;
+  title: string;
+  steps: Step[];
+}
+
+interface DocsSection {
+  id: string;
+  title: string;
+  chapters: Chapter[];
+}
+
+interface Category {
+  id: string;
+  name: string;
+  parentId: string | null;
+  groupId: string | null;
+}
+export function useDocsData(): DocsSection[] {
+  const [docs, setDocs] = useState<DocsSection[]>(fallbackDocsData);
+
+  useEffect(() => {
+    const fetchDocs = async () => {
+      try {
+        const res = await api.get('/category');
+        const categories = res.data;
+
+        if (!Array.isArray(categories) || categories.length === 0) {
+          console.warn('📭 fallbackDocsData 사용');
+          setDocs(fallbackDocsData);
+          return;
+        }
+
+        const groupMap: { [groupId: string]: DocsSection } = {};
+        categories.forEach((cat) => {
+          const groupId = cat.groupId || 'etc';
+          if (!groupMap[groupId]) {
+            groupMap[groupId] = { id: groupId, title: groupId, chapters: [] };
+          }
+          if (cat.parentId === null) {
+            groupMap[groupId].chapters.push({ id: cat.id, title: cat.name, steps: [] });
+          }
+        });
+
+        categories
+          .filter((c) => c.parentId !== null)
+          .forEach((cat) => {
+            for (const section of Object.values(groupMap)) {
+              const chapter = section.chapters.find((ch) => ch.id === cat.parentId);
+              if (chapter) {
+                chapter.steps.push({ id: cat.id, title: cat.name });
+              }
+            }
+          });
+
+        setDocs(Object.values(groupMap));
+      } catch (err) {
+        console.error('문서 데이터 로드 실패, fallback 사용:', err);
+        setDocs(fallbackDocsData); // 다시 보장
+      }
+    };
+
+    fetchDocs();
+  }, []);
+
+  return docs;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,14 +2,24 @@ import axios from 'axios';
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000',
-  withCredentials: true,
+  // withCredentials: true,
 });
+
+// 로컬스토리지의 토큰 헤더 등록
+api.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
 
 api.interceptors.response.use(
   res => res,
-  err => {
-    return Promise.reject(err);
-  }
+  err => Promise.reject(err)
 );
 
 export default api;

--- a/src/pages/dockerDocs/DockerDocsDetail.tsx
+++ b/src/pages/dockerDocs/DockerDocsDetail.tsx
@@ -1,50 +1,46 @@
-import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import TopNav from '../../components/common/TopNav';
-import SelectedStepThread from '../../components/dockerDocs/SelectedStepThread';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useDocsData } from '@/hooks/useDocsData';
+import TopNav from '@/components/common/TopNav';
+import SelectedStepThread from '@/components/dockerDocs/SelectedStepThread';
 import { AnimatePresence } from 'framer-motion';
-import NestedSidebar from '../../components/common/NestedSidebar';
-
-// 임시 목차 데이터..
-import { docsData } from '../../data/docsData';
-
-const chapters = [
-  {
-    id: '1',
-    title: '1장. 도커의 이해',
-    steps: [
-      { id: '1.1', title: '세팅 시작하기', content: '도커 설치 및 환경 설정에 대한 설명입니다.' },
-      { id: '1.2', title: '컨테이너의 이해', content: '컨테이너는 가상 환경을 격리하여 실행하는 기술입니다.' },
-      { id: '1.3', title: '컨테이너란?', content: '이미지로부터 실행된 인스턴스를 말합니다.' },
-    ],
-  },
-  {
-    id: '2',
-    title: '2장. 도커 활용해보기',
-    steps: [
-      { id: '2.1', title: '도커 데스크톱의 역사', content: '도커 데스크톱은 GUI 환경에서 도커를 제어할 수 있게 해줍니다.' },
-      { id: '2.2', title: '도커란?', content: '컨테이너 기반의 가상화 기술을 말합니다.' },
-    ],
-  },
-];
+import NestedSidebar from '@/components/common/NestedSidebar';
+import { docsData as fallbackDocsData } from '@/data/docsData';
 
 export default function DockerDocsDetail() {
-  const { chapterId = '1' } = useParams();
+  const { projectId = 'docker', chapterId = '1' } = useParams();
   const navigate = useNavigate();
   const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
 
-  const currentIndex = chapters.findIndex((c) => c.id === chapterId);
-  const chapter = chapters[currentIndex];
+  const docs = useDocsData();
+  const activeDocs = docs.length > 0 ? docs : fallbackDocsData;
+
+  const project = activeDocs.find(p => p.id === projectId);
+  const chapter = project?.chapters.find(c => c.id === chapterId);
+
+  const flatChapters = project?.chapters ?? [];
+  const currentIndex = flatChapters.findIndex(c => c.id === chapterId);
+
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.hash) {
+      const target = document.getElementById(location.hash.substring(1));
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  }, [location]);
 
   const goToPrev = () => {
     if (currentIndex > 0) {
-      navigate(`/docs/${chapters[currentIndex - 1].id}`);
+      navigate(`/docs/${projectId}/${flatChapters[currentIndex - 1].id}`);
     }
   };
 
   const goToNext = () => {
-    if (currentIndex < chapters.length - 1) {
-      navigate(`/docs/${chapters[currentIndex + 1].id}`);
+    if (currentIndex < flatChapters.length - 1) {
+      navigate(`/docs/${projectId}/${flatChapters[currentIndex + 1].id}`);
     }
   };
 
@@ -52,9 +48,8 @@ export default function DockerDocsDetail() {
     <>
       <TopNav />
       <div className="flex min-h-screen bg-white">
-        <NestedSidebar data={docsData} />
+        <NestedSidebar data={activeDocs} />
 
-        {/* 본문 영역 */}
         <main className="flex-1 relative px-6 py-10 max-w-4xl mx-auto">
           {/* 좌우 화살표 */}
           {currentIndex > 0 && (
@@ -65,7 +60,7 @@ export default function DockerDocsDetail() {
               ⬅
             </button>
           )}
-          {currentIndex < chapters.length - 1 && (
+          {currentIndex < flatChapters.length - 1 && (
             <button
               className="absolute right-0 top-1/2 transform -translate-y-1/2 text-2xl text-gray-500 hover:text-black"
               onClick={goToNext}
@@ -74,32 +69,35 @@ export default function DockerDocsDetail() {
             </button>
           )}
 
-          <h1 className="text-2xl font-bold mb-6">{chapter.title}</h1>
+          {chapter ? (
+            <>
+              <h1 className="text-2xl font-bold mb-6">{chapter.title}</h1>
+              <div className="space-y-8">
+                {chapter.steps.map((step) => (
+                  <section key={step.id} id={step.id}>
+                    <h2
+                      className="text-lg font-semibold mb-2 cursor-pointer hover:underline"
+                      onClick={() => setSelectedStepId(step.id)}
+                    >
+                      {step.title}
+                    </h2>
+                    <p className="text-gray-800 leading-relaxed">내용 없음</p>
+                  </section>
+                ))}
+              </div>
+            </>
+          ) : (
+            <p className="text-blue-500 text-center mt-20">해당 챕터를 찾을 수 없습니다.</p>
+          )}
 
-          {/* 스텝 나열 */}
-          <div className="space-y-8">
-            {chapter.steps.map((step) => (
-              <section key={step.id} id={step.id}>
-                <h2
-                  className="text-lg font-semibold mb-2 cursor-pointer hover:underline"
-                  onClick={() => setSelectedStepId(step.id)}
-                >
-                  {step.id}) {step.title}
-                </h2>
-                <p className="text-gray-800 leading-relaxed">{step.content}</p>
-              </section>
-            ))}
-          </div>
-
-          {/* 슬라이딩 스레드 창 */}
           <AnimatePresence>
-          {selectedStepId && (
-            <SelectedStepThread
+            {selectedStepId && (
+              <SelectedStepThread
                 stepId={selectedStepId}
                 onClose={() => setSelectedStepId(null)}
-            />
+              />
             )}
-        </AnimatePresence>
+          </AnimatePresence>
         </main>
       </div>
     </>

--- a/src/pages/dockerDocs/DockerDocsOverview.tsx
+++ b/src/pages/dockerDocs/DockerDocsOverview.tsx
@@ -1,37 +1,13 @@
 import { useNavigate } from 'react-router-dom';
-import TopNav from '../../components/common/TopNav';
-
-interface Chapter {
-  id: string;
-  title: string;
-  steps: { id: string; title: string }[];
-}
-
-const chapters: Chapter[] = [
-  {
-    id: '1',
-    title: '1장. 도커의 이해',
-    steps: [
-      { id: '1.1', title: '세팅 시작하기' },
-      { id: '1.2', title: '컨테이너의 이해' },
-      { id: '1.3', title: '컨테이너란?' },
-    ],
-  },
-  {
-    id: '2',
-    title: '2장. 도커 활용해보기',
-    steps: [
-      { id: '2.1', title: '도커 데스크톱의 역사' },
-      { id: '2.2', title: '도커란?' },
-    ],
-  },
-];
+import TopNav from '@/components/common/TopNav';
+import { useDocsData } from '@/hooks/useDocsData';
 
 export default function DockerDocsOverview() {
   const navigate = useNavigate();
+  const docs = useDocsData();
 
-  const goToDetail = (chapterId: string, stepId?: string) => {
-    navigate(`/docs/${chapterId}${stepId ? `/${stepId}` : ''}`);
+  const goToDetail = (projectId: string, chapterId: string, stepId?: string) => {
+    navigate(`/docs/${projectId}/${chapterId}${stepId ? `#${stepId}` : ''}`);
   };
 
   return (
@@ -41,28 +17,30 @@ export default function DockerDocsOverview() {
         <div className="max-w-4xl mx-auto">
           <h1 className="text-3xl font-bold mb-6">Docker Docs</h1>
 
-          {chapters.map((chapter) => (
-            <div key={chapter.id} className="mb-8">
-              {/* 중제목 */}
-              <h2
-                className="text-xl font-semibold mt-8 mb-3 cursor-pointer hover:underline"
-                onClick={() => goToDetail(chapter.id)}
-              >
-                {chapter.title}
-              </h2>
-
-              {/* 소제목 */}
-              <ul className="space-y-1">
-                {chapter.steps.map((step) => (
-                  <li
-                    key={step.id}
-                    className="text-sm text-blue-700 hover:underline cursor-pointer block"
-                    onClick={() => goToDetail(chapter.id, step.id)}
+          {docs.map((section) => (
+            <div key={section.id} className="mb-12">
+              <h2 className="text-2xl font-semibold text-gray-800 mb-4">{section.title}</h2>
+              {section.chapters.map((chapter) => (
+                <div key={chapter.id} className="mb-6">
+                  <h3
+                    className="text-xl font-semibold mb-2 cursor-pointer hover:underline"
+                    onClick={() => goToDetail(section.id, chapter.id)}
                   >
-                    {step.id}) {step.title}
-                  </li>
-                ))}
-              </ul>
+                    {chapter.title}
+                  </h3>
+                  <ul className="space-y-1 ml-4">
+                    {chapter.steps.map((step) => (
+                      <li
+                        key={step.id}
+                        className="text-sm text-blue-700 hover:underline cursor-pointer"
+                        onClick={() => goToDetail(section.id, chapter.id, step.id)}
+                      >
+                        {step.title}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
             </div>
           ))}
         </div>

--- a/src/pages/users/FindPwd.tsx
+++ b/src/pages/users/FindPwd.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
 import 'react-toastify/dist/ReactToastify.css';
-import TopNav from '../../components/common/TopNav';
-import api from '../../lib/api';
+import TopNav from '@/components/common/TopNav';
+import api from '@/lib/api';
 
 function FindPwd() {
   const [id, setId] = useState('');

--- a/src/pages/users/FindUser.tsx
+++ b/src/pages/users/FindUser.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
-import TopNav from '../../components/common/TopNav';
-import api from '../../lib/api';
+import TopNav from '@/components/common/TopNav';
+import api from '@/lib/api';
 
 function FindUser() {
   const [email, setEmail] = useState('');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "target": "ESNext",
     "moduleResolution": "node",
     "baseUrl": "./",
-    "paths": {},
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "allowJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,15 @@
 // ESM 문법
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   base: './',
   build: {
     outDir: 'dist',


### PR DESCRIPTION
카테고리/게시글/좋아요 API 연결 완료

아래 내용 확인 필요합니다.

### 2025-06-15 정리
1. 로그인 API에서 이메일을 반환하지 않고 있어서 이메일로 아이디 표기 불가능

2. category 구분 어떻게 해야 하나요?
    EX) Docker(대) - 1장(중) - 1.1장(소)
    쉽게 하는 방법은 (대)를 구분하는 기준을 groupId라는 컬럼같을 걸 추가해서 카테고리분류가 가능하면 좋겠네요.
    저희는 상세한 카테고리분류는 필요없으니 컬럼레벨에서 해소할 수 있겠습니다.

3. 게시글 가져올 때 댓글, 좋아요 카운트도 한번에 조회할 수 있는 API 없을까요?

4. 좋아요 눌러서 좋아요 id가 생성되면 반환되어야 함
    해당 id가지고 유저 액션 연속성 유지 가능